### PR TITLE
Normalize collection name when fetching previous reports

### DIFF
--- a/qdrant_store.py
+++ b/qdrant_store.py
@@ -73,7 +73,7 @@ def save_report_chunks(team: str, uuid: str, chunks, embeddings):
 
 def get_prev_report_chunks(team: str, exclude_uuid: str, limit=2):
     client = get_client()
-    collection = team
+    collection = normalize_collection_name(team)
     try:
         res = client.scroll(collection_name=collection, limit=1000)
     except Exception as e:


### PR DESCRIPTION
## Summary
- normalize the collection name in `get_prev_report_chunks` to match other Qdrant operations

## Testing
- `python -m py_compile qdrant_store.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684800c08b008331874cb186d981f58a