### PR TITLE
Add configurable Allure report path

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,8 @@
 # --- Allure API ---
 # Базовый эндпоинт для получения отчёта
 ALLURE_API_REPORT_ENDPOINT=http://10.15.132.171:8080/api/report
+# Путь до отчёта (по умолчанию - новый эндпоинт test-cases/aggregate)
+ALLURE_API_REPORT_PATH=/test-cases/aggregate
 
 # Базовый эндпоинт для отправки результатов анализа
 ALLURE_API_ANALYSIS_ENDPOINT=http://10.15.132.171:8080/api/analysis/report


### PR DESCRIPTION
## Summary
- make the Allure API report path configurable via `ALLURE_API_REPORT_PATH`
- prefer `/test-cases/aggregate` and fall back to `/suites/json`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68480683733c8331960621e65ae51dd9