### PR TITLE
Make embedding model path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# three_reports_rag
+
+A FastAPI service that analyses multiple Allure reports using retrieval augmented generation (RAG).
+
+## Setup
+
+Install dependencies and download the embedding model used by the service.
+
+```bash
+pip install -r requirements.txt
+```
+
+### Download the embedding model
+
+The application expects a local copy of the model. Use `download_embedding_model.py` to fetch it. The destination can be provided as a command line argument or via the `EMBEDDING_MODEL_PATH` environment variable.
+
+```bash
+python download_embedding_model.py --output-path path/to/local_models/intfloat/multilingual-e5-small
+```
+
+or
+
+```bash
+export EMBEDDING_MODEL_PATH=path/to/local_models/intfloat/multilingual-e5-small
+python download_embedding_model.py
+```
+
+Make sure the same path is supplied to the service through the `EMBEDDING_MODEL_PATH` environment variable.
+
+## Running
+
+After downloading the model, start the API server:
+
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8001
+```
+
+You can also run everything via Docker Compose:
+
+```bash
+docker-compose up --build
+```

--- a/download_embedding_model.py
+++ b/download_embedding_model.py
@@ -1,4 +1,35 @@
+"""Utility to download the embedding model to a user defined location."""
+
+import argparse
+import os
+
 from sentence_transformers import SentenceTransformer
 
-model = SentenceTransformer('intfloat/multilingual-e5-small')
-model.save('C:/Dev/three_reports_rag/local_models/intfloat/multilingual-e5-small')
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download and save the embedding model locally",
+    )
+    parser.add_argument(
+        "--output-path",
+        default=os.getenv("EMBEDDING_MODEL_PATH"),
+        help=(
+            "Directory where the model will be stored. "
+            "If omitted, the EMBEDDING_MODEL_PATH environment variable is used."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not args.output_path:
+        parser.error(
+            "Output path must be provided via --output-path or EMBEDDING_MODEL_PATH"
+        )
+
+    os.makedirs(args.output_path, exist_ok=True)
+    model = SentenceTransformer("intfloat/multilingual-e5-small")
+    model.save(args.output_path)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- make model download path configurable via CLI or `EMBEDDING_MODEL_PATH`
- document how to download the embedding model in a new README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6848069cea248331ad62227083e4bc7a