### PR TITLE
Remove image path from LLM prompts

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -6,12 +6,12 @@ OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
 LLM_MODEL = os.getenv("LLM_MODEL", "gemma3:4b")
 
 def analyze_reports(report, prev_reports, plot_img_path):
+    # "plot_img_path" is kept for backward compatibility but is not used in the
+    # LLM prompt. The model operates only on textual data.
     # Формируем промпт для LLM
     prompt = (
         "Ты — эксперт по автотестам. Проведи глубокий анализ текущего отчёта и сравни с предыдущими. "
-        f"Кратко: в чем основные тренды, какие ошибки повторяются, есть ли улучшения или деградация? "
-        "Выполни также статистический и визуальный анализ на основе приложенного графика по пути: "
-        f"{plot_img_path}.\n\n"
+        "Кратко: в чем основные тренды, какие ошибки повторяются, есть ли улучшения или деградация?\n\n"
         "Данные текущего отчёта:\n"
         f"{report}\n\n"
         "Данные прошлых отчётов:\n"

--- a/utils.py
+++ b/utils.py
@@ -35,7 +35,9 @@ def analyze_cases_with_llm(all_reports, team_name, trend_text=None, trend_img_pa
     trend_text : str, optional
         Textual representation of trends for the LLM.
     trend_img_path : str, optional
-        Path to the trend image created by :mod:`plotter`.
+        Path to the trend image created by :mod:`plotter`. The image is
+        returned as an Allure attachment but is not included in the LLM
+        prompt.
     """
 
     from collections import Counter, defaultdict
@@ -170,8 +172,6 @@ def analyze_cases_with_llm(all_reports, team_name, trend_text=None, trend_img_pa
 
     if trend_text:
         text += f"\nТренд по датам:\n{trend_text}\n"
-    if trend_img_path:
-        text += f"\nИзображение тренда находится по пути: {trend_img_path}\n"
 
     text += ("\nСделай вывод о стабильности тестов, ключевых проблемах и дай краткие рекомендации."
              " Ответ дай на русском, по существу.")


### PR DESCRIPTION
## Summary
- omit trend image reference from LLM prompts
- clarify how the image path is used in `utils.analyze_cases_with_llm`
- keep compatibility in `analyzer.analyze_reports`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493fc738208331a40524a31df28cd6