### PR TITLE
Fix not to send trend graph when LLM call fails

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -181,18 +181,20 @@ def analyze_cases_with_llm(all_reports, team_name, trend_text=None, trend_img_pa
         "prompt": text,
         "stream": False,
     }
+    llm_ok = True
     try:
         response = requests.post(ollama_url, json=payload, timeout=120)
         response.raise_for_status()
         result = response.json()
         summary = result.get("response", "").strip() or result.get("message", "Нет ответа от LLM")
     except Exception as e:
+        llm_ok = False
         summary = f"Ошибка вызова LLM: {e}"
 
     rules = [
         ("auto-analysis", summary)
     ]
-    if trend_img_path:
+    if trend_img_path and llm_ok:
         rules.append(("trend-graph", trend_img_path))
 
     return summary, rules


### PR DESCRIPTION
## Summary
- handle LLM failures and avoid adding the trend-graph rule when the request fails

## Testing
- `python -m py_compile utils.py`
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6849474df40c833196191c098c372766