### PR TITLE
Fix Ollama integration in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,5 @@ You can also run everything via Docker Compose:
 docker-compose up --build
 ```
 
-### Launching the LLM container
-
-Before starting the stack, run the Ollama container so that the FastAPI service can reach the LLM:
-
-```bash
-docker run -d --name ollama -p 11434:11434 ollama/ollama
-```
-
-Once it's running, rebuild and start the rest of the services:
-
-```bash
-docker-compose up --build
-```
+The Compose stack now includes the Ollama container used for LLM requests. Simply
+run `docker-compose up` and all services, including Ollama, will start automatically.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,14 +7,20 @@ services:
     volumes:
       - ./qdrant_data:/qdrant/storage
 
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+
   rag_app:
     build: .
     depends_on:
       - qdrant
+      - ollama
     environment:
       QDRANT_HOST: qdrant         # важно: docker-сервис, не localhost!
       QDRANT_PORT: 6333
-      OLLAMA_URL: "http://localhost:11434/api/generate"
+      OLLAMA_URL: "http://ollama:11434/api/generate"
       LLM_MODEL: "gemma3:4b"
       # (другие env из .env при желании)
     volumes:


### PR DESCRIPTION
## Summary
- include `ollama` container in `docker-compose.yml`
- reference the Ollama service from `rag_app`
- clarify Compose usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684949ec06448331bd909605681b2316