### PR TITLE
Return timestamps with previous report chunks

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,14 +49,15 @@ async def analyze_uuid(req: AnalyzeRequest):
         maintain_last_n_reports(team_name, n=REPORTS_HISTORY_DEPTH, current_uuid=uuid)
         # 6. Получаем чанки из предыдущих отчётов (от старого к новому!)
         prev_limit = max(REPORTS_HISTORY_DEPTH - 1, 0)
-        prev_chunks = get_prev_report_chunks(team_name, exclude_uuid=uuid, limit=prev_limit)
+        prev_reports = get_prev_report_chunks(team_name, exclude_uuid=uuid, limit=prev_limit)
 
         # 7. Собираем для plotter: 2 prev + текущий
         all_reports = []
         all_uuids = []
         all_teams = []
-        # prev_chunks — это dict {uuid: [cases]}
-        for report_uuid, chunks in prev_chunks.items():
+        # prev_reports — это dict {uuid: {"timestamp": ts, "chunks": [...]}}
+        for report_uuid, data in prev_reports.items():
+            chunks = data.get("chunks", [])
             if chunks:
                 all_reports.append(chunks)
                 all_uuids.append(report_uuid)

--- a/qdrant_store.py
+++ b/qdrant_store.py
@@ -93,7 +93,10 @@ def get_prev_report_chunks(team: str, exclude_uuid: str, limit=2):
     sorted_reports = sorted(
         reports.items(), key=lambda x: x[1]["timestamp"], reverse=True
     )[:limit]
-    return {uid: data["chunks"] for uid, data in sorted_reports}
+    return {
+        uid: {"timestamp": data["timestamp"], "chunks": data["chunks"]}
+        for uid, data in sorted_reports
+    }
 
 
 def maintain_last_n_reports(team, n, current_uuid):


### PR DESCRIPTION
## Summary
- include timestamps in `get_prev_report_chunks`
- update caller in `main.py` to use new structure

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849755af0ac833186d91b2fbd280cca