### PR TITLE
Include report summary in Allure analysis payload

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,6 +97,8 @@ async def analyze_uuid(req: AnalyzeRequest):
 
         summary, rules = utils.analyze_cases_with_llm(all_reports, team_name, trend_text, img_path)
         analysis = [{"rule": rule, "message": msg} for rule, msg in rules]
+        # Prepend the report summary for Allure consumers
+        analysis.insert(0, {"rule": "report-info", "message": report_info})
         utils.send_analysis_to_allure(uuid, analysis)
 
         return {"result": "ok", "report_info": report_info, "summary": summary, "analysis": analysis}


### PR DESCRIPTION
## Summary
- prepend report summary to the analysis list before sending to Allure

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68497b27d2248331a3a56077ca70d993