### PR TITLE
Fix error clustering when traces are missing

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -106,7 +106,8 @@ def analyze_cases_with_llm(all_reports, team_name, trend_text=None, trend_img_pa
         if status in {"failed", "broken"}:
             msg = c.get("statusMessage") or ""
             trace = c.get("statusTrace") or ""
-            key = (msg.splitlines()[0] if msg else trace.splitlines()[0])[:120]
+            lines = msg.splitlines() or trace.splitlines()
+            key = lines[0][:120] if lines else ""
             if key:
                 error_clusters[key] += 1
             if "no such element" in trace.lower() or "nosuchelement" in trace.lower() or "element not found" in msg.lower():


### PR DESCRIPTION
## Summary
- handle missing `statusMessage` and `statusTrace` when building error clusters in `utils.analyze_cases_with_llm`

## Testing
- `python -m py_compile utils.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684a7743c0f8833189caad1056bbdc9e