### PR TITLE
Use stored timestamps in report summaries

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,12 +56,15 @@ async def analyze_uuid(req: AnalyzeRequest):
         all_reports = []
         all_uuids = []
         all_teams = []
+        all_timestamps = []
         # prev_reports — это dict {uuid: {"timestamp": ts, "chunks": [...]}}
         for report_uuid, data in prev_reports.items():
             chunks = data.get("chunks", [])
+            ts = int(data.get("timestamp", 0))
             if chunks:
                 all_reports.append(chunks)
                 all_uuids.append(report_uuid)
+                all_timestamps.append(ts)
                 # Название команды из labels первого кейса
                 team = None
                 if isinstance(chunks[0], dict) and chunks[0].get("labels"):
@@ -74,16 +77,18 @@ async def analyze_uuid(req: AnalyzeRequest):
         all_reports.append(report)
         all_uuids.append(uuid)
         all_teams.append(team_name)
+        all_timestamps.append(timestamp)
 
         # Оставляем только последние REPORTS_HISTORY_DEPTH (если вдруг больше)
         if len(all_reports) > REPORTS_HISTORY_DEPTH:
             all_reports = all_reports[-REPORTS_HISTORY_DEPTH:]
             all_uuids = all_uuids[-REPORTS_HISTORY_DEPTH:]
             all_teams = all_teams[-REPORTS_HISTORY_DEPTH:]
+            all_timestamps = all_timestamps[-REPORTS_HISTORY_DEPTH:]
 
         # 8. Генерируем сводку по отчетам и тренды
-        report_info = format_reports_summary(all_reports, color=True)
-        report_info_plain = format_reports_summary(all_reports, color=False)
+        report_info = format_reports_summary(all_reports, color=True, timestamps=all_timestamps)
+        report_info_plain = format_reports_summary(all_reports, color=False, timestamps=all_timestamps)
         img_path = plot_trends_for_reports(all_reports, all_uuids, all_teams)
 
         # 9. Формируем текстовую аналитику

--- a/tests/test_report_summary.py
+++ b/tests/test_report_summary.py
@@ -12,7 +12,8 @@ def test_format_date_positive():
     assert _format_date(ts) == expected
 
 
-def test_format_date_unknown():
-    assert _format_date(0) == "unknown"
-    assert _format_date(-123) == "unknown"
+def test_format_date_non_positive():
+    expected = datetime.fromtimestamp(0).strftime('%d.%m.%Y')
+    assert _format_date(0) == expected
+    assert _format_date(-123) == expected
 


### PR DESCRIPTION
## Summary
- use timestamp from start or stored value when summarising reports
- allow `format_reports_summary` to accept timestamps
- adjust FastAPI endpoint to supply report timestamps
- always format timestamps in `_format_date`
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a80e6b6d88331a0405af79614e8e1