### PR TITLE
Switch status formatting to HTML spans

### DIFF
--- a/report_summary.py
+++ b/report_summary.py
@@ -14,6 +14,16 @@ ANSI_COLORS = {
     "reset": "\033[0m",
 }
 
+# HTML color mapping used when ``color=True`` is requested by
+# :func:`format_reports_summary`.  React does not understand ANSI
+# escape codes, so we output ``<span>`` tags instead.
+HTML_COLORS = {
+    "passed": "green",
+    "failed": "red",
+    "broken": "orange",
+    "skipped": "gray",
+}
+
 
 def _format_date(ts: int) -> str:
     """Return ``dd.mm.yyyy (HH:MM)`` formatted date for ``ts`` seconds since epoch."""
@@ -126,7 +136,10 @@ def extract_report_info(report: List[Dict[str, Any]], fallback_timestamp: int = 
 
 def _fmt_status(s: str, cnt: int, color: bool) -> str:
     if color:
-        return f"{ANSI_COLORS[s]}{s}={cnt}{ANSI_COLORS['reset']}"
+        html_color = HTML_COLORS.get(s)
+        if html_color:
+            return f"<span style=\"color: {html_color};\">{s}={cnt}</span>"
+        return f"{s}={cnt}"
     return f"{s}={cnt}"
 
 

--- a/tests/test_report_summary.py
+++ b/tests/test_report_summary.py
@@ -10,3 +10,15 @@ def test_format_date_valid():
     ts = 1700000000
     expected = datetime.fromtimestamp(ts).strftime('%d.%m.%Y (%H:%M)')
     assert report_summary._format_date(ts) == expected
+
+
+def test_fmt_status_html_output():
+    text = report_summary._fmt_status('passed', 2, True)
+    assert '<span' in text
+    assert 'passed=2' in text
+    assert 'color:' in text
+
+
+def test_fmt_status_plain_output():
+    text = report_summary._fmt_status('failed', 3, False)
+    assert text == 'failed=3'


### PR DESCRIPTION
## Summary
- colorized report statuses using HTML spans so React can render them
- add tests for new HTML output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac8ea0e948331a9bfd844315a26a3