### PR TITLE
Implement ALLURE_ALLOW_ATTACHMENTS flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ docker-compose up --build
 
 The Compose stack now includes the Ollama container used for LLM requests. Simply
 run `docker-compose up` and all services, including Ollama, will start automatically.
+
+## Environment variables
+
+Set `ALLURE_ALLOW_ATTACHMENTS=true` to enable uploading attachments when sending
+analysis results to the Allure API. If not set, only the JSON payload is sent.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,6 +61,7 @@ def test_send_analysis_with_files(monkeypatch, tmp_path):
     monkeypatch.setenv("ALLURE_API_ANALYSIS_ENDPOINT", "http://x")
     monkeypatch.setenv("ALLURE_API_USER", "u")
     monkeypatch.setenv("ALLURE_API_PASSWORD", "p")
+    monkeypatch.setenv("ALLURE_ALLOW_ATTACHMENTS", "false")
     monkeypatch.setattr(utils.requests, "post", fake_post)
 
     path = tmp_path / "trend.png"
@@ -69,6 +70,5 @@ def test_send_analysis_with_files(monkeypatch, tmp_path):
         analysis = [{"rule": "trend-image", "attachment": f}]
         utils.send_analysis_to_allure("uid", analysis, files={"trend-image": f})
 
-    assert "files" in captured
-    assert "trend-image" in captured["files"]
-    assert "analysis" in captured["files"]
+    assert "json" in captured
+    assert captured["json"] == analysis

--- a/utils.py
+++ b/utils.py
@@ -25,6 +25,10 @@ def send_analysis_to_allure(uuid, analysis, files=None):
     user = get_env("ALLURE_API_USER")
     pwd = get_env("ALLURE_API_PASSWORD")
 
+    allow_attachments = (
+        get_env("ALLURE_ALLOW_ATTACHMENTS", "false").lower() == "true"
+    )
+
     attachments = {}
     # Extract attachments from analysis entries if present
     for item in analysis:
@@ -40,7 +44,7 @@ def send_analysis_to_allure(uuid, analysis, files=None):
 
     auth = HTTPBasicAuth(user, pwd)
 
-    if attachments:
+    if allow_attachments and attachments:
         # Multipart request with JSON part and attachments
         multipart = {"analysis": (None, json.dumps(analysis), "application/json")}
         for key, f in attachments.items():


### PR DESCRIPTION
## Summary
- respect `ALLURE_ALLOW_ATTACHMENTS` in `send_analysis_to_allure`
- document the new environment variable
- update test to expect JSON payload when attachments are disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2fd673c483319944b84aace1f82f